### PR TITLE
Handle binding extraction returning nothing

### DIFF
--- a/pkg/binder/binder.go
+++ b/pkg/binder/binder.go
@@ -43,6 +43,9 @@ func (b *Binder) Match(tok ltl.Token) (ltl.Operator, ltl.Environment) {
 	if err != nil {
 		return nil, ltl.ErrEnv(err)
 	}
+	if bs == nil {
+		return nil, ltl.NotMatching
+	}
 	ops := []be.Option{be.Bound(bs)}
 	if b.capture {
 		ops = append(ops, be.Captured(tok))
@@ -71,6 +74,9 @@ func (r *Referencer) Match(tok ltl.Token) (ltl.Operator, ltl.Environment) {
 	bs, err := r.extractToken(r.name, tok)
 	if err != nil {
 		return nil, ltl.ErrEnv(err)
+	}
+	if bs == nil {
+		return nil, ltl.NotMatching
 	}
 	ops := []be.Option{be.Referenced(bs)}
 	if r.capture {


### PR DESCRIPTION
Handle cases where the bindings token extractor doesn't return a bindings, by returning a non-matching environment.
Tests continue to pass.